### PR TITLE
Blog app - API documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'webdrivers' # allow interact with the browser. (supporting capybara)
+
+  
 end
 
 group :development do
@@ -76,3 +78,4 @@ end
 
 gem 'cancancan'
 gem 'devise'
+gem 'rswag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     jwt (2.7.1)
     loofah (2.21.3)
       crass (~> 1.0.2)
@@ -208,6 +210,20 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rswag (2.11.0)
+      rswag-api (= 2.11.0)
+      rswag-specs (= 2.11.0)
+      rswag-ui (= 2.11.0)
+    rswag-api (2.11.0)
+      railties (>= 3.1, < 7.2)
+    rswag-specs (2.11.0)
+      activesupport (>= 3.1, < 7.2)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.2)
+      rspec-core (>= 2.14)
+    rswag-ui (2.11.0)
+      actionpack (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
     rubyzip (2.3.2)
     selenium-webdriver (4.13.1)
       rexml (~> 3.2, >= 3.2.5)
@@ -268,6 +284,7 @@ DEPENDENCIES
   rails (~> 7.0.8)
   rails-controller-testing
   rspec-rails
+  rswag
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users
   get '/users/sign_out', to: 'users#user_sign_out', as: 'sign_out'
 

--- a/sApiDoc.txt
+++ b/sApiDoc.txt
@@ -1,0 +1,10 @@
+# Add gem for auto build API docs
+# Condition is to build a test first
+gem 'rswag'
+
+
+Ter: bundle i
+Ter: rails g rswag:install
+
+# create a file for testing api/v1/comments_controller
+Ter: rails generate rspec:swagger api::v1::comments_controller

--- a/spec/requests/comments_api_spec.rb
+++ b/spec/requests/comments_api_spec.rb
@@ -1,0 +1,68 @@
+require 'swagger_helper'
+
+describe 'Comments API' do
+  before :each do
+    @user1 = User.create(name: 'user1', bio: 'bio1', photo: 'photo1')
+    @user2 = User.create(name: 'user2', bio: 'bio2', photo: 'photo2')
+    @post1 = Post.create(author_id: @user1.id, title: 'Post 1', text: 'text 1')
+    @post2 = Post.create(author_id: @user1.id, title: 'Post 2', text: 'text 2')
+    @post3 = Post.create(author_id: @user1.id, title: 'Post 3', text: 'text 3')
+    @post4 = Post.create(author_id: @user1.id, title: 'Post 4', text: 'text 4')
+
+    @post1.comments.create(user_id: @user1.id, text: 'from user1')
+    @post1.comments.create(user_id: @user1.id, text: 'from user2')
+    @post1.comments.create(user_id: @user2.id, text: 'from user3')
+    @post1.comments.create(user_id: @user2.id, text: 'from user4')
+    @post1.comments.create(user_id: @user1.id, text: 'from user5')
+    @post1.comments.create(user_id: @user1.id, text: 'from user6')
+    @post1.comments.create(user_id: @user1.id, text: 'from user7')
+  end
+
+  path "api_v1_user_post_comments" do
+    get "show all comments" do
+      tags 'Comments'
+      produces 'application/json', 'application/xml'
+      parameter name: :id, in: :path, type: :string
+      request_body_example value: { 
+        success: true,
+      }, name: 'basic', summary: 'Request example description'
+  
+        response '200', 'comments found' do
+          schema type: :object,
+            properties: {
+              id: { type: :integer },
+              text: { type: :string },
+            },
+            required: ['text']
+  
+          let(i) {
+            @user1 = User.create(name: 'user1', bio: 'bio1', photo: 'photo1')
+            @post1 = Post.create(author_id: @user1.id, title: 'Post 1', text: 'text 1')
+          
+            @post1.comments.create(user_id: @user1.id, text: 'from user1')
+            @post1.comments.create(user_id: @user1.id, text: 'from user2')
+          }
+            
+          
+
+          run_test!
+        end
+
+        response '404', 'blog not found' do
+          let(:id) { 'invalid' }
+          run_test!
+        end
+    
+        response '406', 'unsupported accept header' do
+          let(:'Accept') { 'application/foo' }
+          run_test!
+        end
+
+
+    end
+
+
+  end
+
+
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end


### PR DESCRIPTION
Write the API integration specs using [rswag](https://github.com/rswag/rswag#getting-started) for your existing endpoints.
Generate the documentation.